### PR TITLE
Remove old kubernetes client as a dependency

### DIFF
--- a/chatgpt_robusta_actions/chat_gpt.py
+++ b/chatgpt_robusta_actions/chat_gpt.py
@@ -10,7 +10,7 @@ cache_size = 100
 lru_cache = cachetools.LRUCache(maxsize=cache_size)
 class ChatGPTTokenParams(ActionParams):
     """
-    :var token: ChatGPT auth token
+    :var chat_gpt_token: ChatGPT auth token
     """
     chat_gpt_token: str
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = ""
 authors = ["Arik Alon <arikalon1@users.noreply.github.com>"]
 
 [tool.poetry.dependencies]
-kubernetes = "^12.0.1"
 openai = "^0.27.2"
 cachetools = "^5.3.0"
 


### PR DESCRIPTION
When installed, this was overriding the newer library version Robusta itself installed.

We can rely on this always existing anyway.